### PR TITLE
Move to Quay.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
+REGISTRY := quay.io
+DEFAULT_TAG := latest
+
 ifeq ($(TARGET),rhel)
   DOCKERFILE := Dockerfile.rhel
-  REGISTRY := push.registry.devshift.net/osio-prod
+  REPOSITORY := openshiftio/rhel-fabric8-analytics-f8a-3scale-connect-api
 else
   DOCKERFILE := Dockerfile
-  REGISTRY := push.registry.devshift.net
+  REPOSITORY := openshiftio/fabric8-analytics-f8a-3scale-connect-api
 endif
-REPOSITORY?=fabric8-analytics/f8a-3scale-connect-api
-DEFAULT_TAG=latest
 
 .PHONY: all docker-build fast-docker-build test get-image-name get-image-repository docker-build-tests fast-docker-build-tests
 

--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -9,4 +9,3 @@ build_image
 #IMAGE_NAME=$(make get-image-name) ./runtest.sh
 
 push_image
-

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -1,12 +1,19 @@
 #!/bin/bash -ex
 
 load_jenkins_vars() {
-    if [ -e "jenkins-env" ]; then
-        cat jenkins-env \
-          | grep -E "(DEVSHIFT_TAG_LEN|DEVSHIFT_USERNAME|DEVSHIFT_PASSWORD|JENKINS_URL|GIT_BRANCH|GIT_COMMIT|BUILD_NUMBER|ghprbSourceBranch|ghprbActualCommit|BUILD_URL|ghprbPullId)=" \
-          | sed 's/^/export /g' \
-          > ~/.jenkins-env
-        source ~/.jenkins-env
+    if [ -e "jenkins-env.json" ]; then
+        eval "$(./env-toolkit load -f jenkins-env.json \
+                DEVSHIFT_TAG_LEN \
+                QUAY_USERNAME \
+                QUAY_PASSWORD \
+                JENKINS_URL \
+                GIT_BRANCH \
+                GIT_COMMIT \
+                BUILD_NUMBER \
+                ghprbSourceBranch \
+                ghprbActualCommit \
+                BUILD_URL \
+                ghprbPullId)"
     fi
 }
 
@@ -20,8 +27,8 @@ build_image() {
     local push_registry
     push_registry=$(make get-push-registry)
     # login before build to be able to pull RHEL parent image
-    if [ -n "${DEVSHIFT_USERNAME}" -a -n "${DEVSHIFT_PASSWORD}" ]; then
-        docker login -u ${DEVSHIFT_USERNAME} -p ${DEVSHIFT_PASSWORD} ${push_registry}
+    if [ -n "${QUAY_USERNAME}" -a -n "${QUAY_PASSWORD}" ]; then
+        docker login -u ${QUAY_USERNAME} -p ${QUAY_PASSWORD} ${push_registry}
     else
         echo "Could not login, missing credentials for the registry"
         exit 1

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -120,13 +120,13 @@ parameters:
   displayName: Docker registry
   required: true
   name: DOCKER_REGISTRY
-  value: "registry.devshift.net"
+  value: "quay.io"
 
 - description: Docker image to use
   displayName: Docker image
   required: true
   name: DOCKER_IMAGE
-  value: "fabric8-analytics/f8a-3scale-connect-api"
+  value: "openshiftio/rhel-fabric8-analytics-f8a-3scale-connect-api"
 
 - description: Image tag
   displayName: Image tag


### PR DESCRIPTION
This PR is part of the effort to move to Quay.

This is the list of changes in this PR:

- Pushes to Quay instead of the Devshift registry
- Uses an image hosted in Quay to build the RHEL based container image
- Uses the new env-toolkit to load variables from jenkins-env
- Changes the default path of the image to quay (note that this should not affect production because it is overridden in the saas repo)

A companion PR should have been submitted to the appropriate saas repo to change the staging url from devshift to quay. The PR to the saas repo should be merged before this one.
https://github.com/openshiftio/saas-analytics/pull/407